### PR TITLE
Erc165 storage

### DIFF
--- a/contracts/Governor/GovernorFactory.sol
+++ b/contracts/Governor/GovernorFactory.sol
@@ -1,7 +1,6 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 
@@ -11,7 +10,7 @@ import "../interfaces/ITimelock.sol";
 
 /// @dev Governor Factory used to deploy Gov Modules
 /// @dev Deploys Timelock dependecies
-contract GovernorFactory is ERC165, ModuleFactoryBase {
+contract GovernorFactory is ModuleFactoryBase {
     event GovernorCreated(address timelock, address governorModule);
 
     function initialize() external initializer {
@@ -94,20 +93,5 @@ contract GovernorFactory is ERC165, ModuleFactoryBase {
             abi.decode(data[9], (uint256)),
             abi.decode(data[1], (address))
         );
-    }
-
-    /// @notice Returns whether a given interface ID is supported
-    /// @param interfaceId An interface ID bytes4 as defined by ERC-165
-    /// @return bool Indicates whether the interface is supported
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC165, ModuleFactoryBase)
-        returns (bool)
-    {
-        return
-            interfaceId == type(IModuleFactory).interfaceId ||
-            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/Governor/GovernorModule.sol
+++ b/contracts/Governor/GovernorModule.sol
@@ -53,6 +53,7 @@ contract GovernorModule is
         __GovernorTimelock_init(_timelock);
         __initBase(_accessControl, msg.sender, "Governor Module");
         __GovernorPreventLateQuorum_init(_initialVoteExtension);
+        _registerInterface(type(IGovernorModule).interfaceId);
     }
 
     // The following functions are overrides required by Solidity.
@@ -246,7 +247,7 @@ contract GovernorModule is
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(GovernorUpgradeable, GovernorTimelock, ModuleBase)
+        override(GovernorUpgradeable, ERC165Storage, IERC165Upgradeable)
         returns (bool)
     {
         return interfaceId == type(IGovernorModule).interfaceId ||

--- a/contracts/Governor/GovernorModule.sol
+++ b/contracts/Governor/GovernorModule.sol
@@ -54,6 +54,7 @@ contract GovernorModule is
         __initBase(_accessControl, msg.sender, "Governor Module");
         __GovernorPreventLateQuorum_init(_initialVoteExtension);
         _registerInterface(type(IGovernorModule).interfaceId);
+        _registerInterface(type(IGovernorTimelock).interfaceId);
     }
 
     // The following functions are overrides required by Solidity.
@@ -134,7 +135,6 @@ contract GovernorModule is
         override(
             GovernorPreventLateQuorumUpgradeable,
             GovernorUpgradeable,
-            IGovernorUpgradeable,
             IGovernorModule
         )
         returns (uint256)
@@ -174,7 +174,7 @@ contract GovernorModule is
         string memory description
     )
         public
-        override(GovernorUpgradeable, IGovernorUpgradeable, IGovernorModule)
+        override(GovernorUpgradeable, IGovernorModule)
         returns (uint256)
     {
         return super.propose(targets, values, calldatas, description);
@@ -237,7 +237,7 @@ contract GovernorModule is
 
     /// @notice Returns the module name
     /// @return The module name
-    function name() public view override(ModuleBase, GovernorUpgradeable, IGovernorUpgradeable) returns (string memory) {
+    function name() public view override(ModuleBase, GovernorUpgradeable) returns (string memory) {
       return _name;
     }
 
@@ -247,7 +247,7 @@ contract GovernorModule is
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(GovernorUpgradeable, ERC165Storage, IERC165Upgradeable)
+        override(GovernorUpgradeable, ERC165Storage)
         returns (bool)
     {
         return interfaceId == type(IGovernorModule).interfaceId ||

--- a/contracts/Governor/GovernorTimelock.sol
+++ b/contracts/Governor/GovernorTimelock.sol
@@ -39,22 +39,6 @@ abstract contract GovernorTimelock is
         _updateTimelock(timelockAddress);
     }
 
-
-    /// @dev See {IERC165-supportsInterface}.
-    /// @param interfaceId An interface ID bytes4 as defined by ERC-165
-    /// @return bool Indicates whether the interface is supported
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(IERC165Upgradeable, GovernorUpgradeable)
-        returns (bool)
-    {
-        return
-            interfaceId == type(IGovernorTimelock).interfaceId ||
-            super.supportsInterface(interfaceId);
-    }
-
     /// @dev Overriden version of the {Governor-state} function with added support for the `Queued` status.
     /// @param proposalId keccak256 hash of proposal params
     function state(uint256 proposalId)

--- a/contracts/Governor/Timelock.sol
+++ b/contracts/Governor/Timelock.sol
@@ -34,6 +34,7 @@ contract Timelock is ModuleBase, ITimelock {
         __initBase(_accessControl, msg.sender, "Timelock Module");
         dao = IDAO(_dao);
         minDelay = _minDelay;
+        _registerInterface(type(ITimelock).interfaceId);
         emit MinDelayChange(0, minDelay);
     }
 

--- a/contracts/interfaces/IGovernorTimelock.sol
+++ b/contracts/interfaces/IGovernorTimelock.sol
@@ -9,22 +9,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 /// delay, enforced by the {TimelockController} to all successful proposal (in addition to the voting duration). The
 /// {Governor} needs to be authorized within the Access Control Contract in order to execute transactions on the TimelockController.
 /// Using this model means the proposal will be operated by the MVD.
-abstract contract IGovernorTimelock is
-    Initializable,
-    IGovernorUpgradeable
-{
+interface IGovernorTimelock {
+    event TimelockChange(address oldTimelock, address newTimelock);
     event ProposalQueued(uint256 proposalId, uint256 eta);
-    /// @dev Public accessor to check the address of the timelock
-    function timelock() public view virtual returns (address);
-
-    /// @dev Public accessor to check the eta of a queued proposal
-    /// @param proposalId keccak256 hash of proposal params
-    function proposalEta(uint256 proposalId)
-        public
-        view
-        virtual
-        returns (uint256);
-
+    
     /// @dev Function to queue a proposal to the timelock.
     /// @param targets Contract addresses the DAO will call
     /// @param values Ether values to be sent to the target address
@@ -35,12 +23,16 @@ abstract contract IGovernorTimelock is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) public virtual returns (uint256 proposalId);
+    ) external returns (uint256);
 
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint256[50] private __gap;
+    /// @dev Overriden version of the {Governor-state} function with added support for the `Queued` status.
+    /// @param proposalId keccak256 hash of proposal params
+    function state(uint256 proposalId) external returns (IGovernorUpgradeable.ProposalState);
+
+    /// @dev Public accessor to check the address of the timelock
+    function timelock() external view returns (address);
+
+    /// @dev Public accessor to check the eta of a queued proposal
+    /// @param proposalId keccak256 hash of proposal params
+    function proposalEta(uint256 proposalId) external view returns (uint256);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fractal-framework/module-governor",
       "version": "0.1.0",
       "devDependencies": {
-        "@fractal-framework/core-contracts": "^0.1.2",
+        "@fractal-framework/core-contracts": "^0.1.3",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
         "@nomiclabs/hardhat-etherscan": "^2.1.8",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@fractal-framework/core-contracts": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.2.tgz",
-      "integrity": "sha512-uDPvqsihfLXB57UZ6XcwlPcZuDoircpNqFNLt5405qgu2UWBPL7t6hhu0bBTXPXQPqazKVxCP8Zkn91ZyJVUGA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.3.tgz",
+      "integrity": "sha512-32hz/aRgmQD7LmT0GVNMt8Al3lqa8RrrmFJCwsK8aSD3IqQbertUmXNe6gCZbXphZQlSu0pIwzM/b+WoIVpcpw==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -24447,9 +24447,9 @@
       }
     },
     "@fractal-framework/core-contracts": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.2.tgz",
-      "integrity": "sha512-uDPvqsihfLXB57UZ6XcwlPcZuDoircpNqFNLt5405qgu2UWBPL7t6hhu0bBTXPXQPqazKVxCP8Zkn91ZyJVUGA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.3.tgz",
+      "integrity": "sha512-32hz/aRgmQD7LmT0GVNMt8Al3lqa8RrrmFJCwsK8aSD3IqQbertUmXNe6gCZbXphZQlSu0pIwzM/b+WoIVpcpw==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "hardhat test"
   },
   "devDependencies": {
-    "@fractal-framework/core-contracts": "^0.1.2",
+    "@fractal-framework/core-contracts": "^0.1.3",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/test/Governor.test.ts
+++ b/test/Governor.test.ts
@@ -14,6 +14,7 @@ import {
   IGovernorModule__factory,
   IModuleBase__factory,
   IERC165__factory,
+  IGovernorTimelock__factory,
 } from "../typechain-types";
 import chai from "chai";
 import { ethers, network } from "hardhat";
@@ -178,12 +179,20 @@ describe("Gov Module", function () {
       );
     });
 
-    it("Supports the expected ERC165 interface", async () => {
+    it.only("Supports the expected ERC165 interface", async () => {
       // Supports Governor Module interface
       expect(
         await govModule.supportsInterface(
           // eslint-disable-next-line camelcase
           getInterfaceSelector(IGovernorModule__factory.createInterface())
+        )
+      ).to.eq(true);
+
+      // Supports Governor Timelock interface
+      expect(
+        await govModule.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IGovernorTimelock__factory.createInterface())
         )
       ).to.eq(true);
 

--- a/test/Governor.test.ts
+++ b/test/Governor.test.ts
@@ -179,7 +179,7 @@ describe("Gov Module", function () {
       );
     });
 
-    it.only("Supports the expected ERC165 interface", async () => {
+    it("Supports the expected ERC165 interface", async () => {
       // Supports Governor Module interface
       expect(
         await govModule.supportsInterface(

--- a/test/Governor.test.ts
+++ b/test/Governor.test.ts
@@ -6,11 +6,14 @@ import {
   DAOAccessControl__factory,
   Timelock,
   Timelock__factory,
+  ITimelock__factory,
   DAO,
   DAO__factory,
   GovernorModule,
   GovernorModule__factory,
   IGovernorModule__factory,
+  IModuleBase__factory,
+  IERC165__factory,
 } from "../typechain-types";
 import chai from "chai";
 import { ethers, network } from "hardhat";
@@ -176,15 +179,53 @@ describe("Gov Module", function () {
     });
 
     it("Supports the expected ERC165 interface", async () => {
-      // Supports DAO Factory interface
+      // Supports Governor Module interface
       expect(
         await govModule.supportsInterface(
           // eslint-disable-next-line camelcase
           getInterfaceSelector(IGovernorModule__factory.createInterface())
         )
       ).to.eq(true);
+
+      // Supports ModuleBase interface
+      expect(
+        await govModule.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IModuleBase__factory.createInterface())
+        )
+      ).to.eq(true);
+
       // Supports ERC-165 interface
-      expect(await govModule.supportsInterface("0x01ffc9a7")).to.eq(true);
+      expect(
+        await govModule.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IERC165__factory.createInterface())
+        )
+      ).to.eq(true);
+
+      // Supports Timelock interface
+      expect(
+        await timelock.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(ITimelock__factory.createInterface())
+        )
+      ).to.eq(true);
+
+      // Supports ModuleBase interface
+      expect(
+        await timelock.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IModuleBase__factory.createInterface())
+        )
+      ).to.eq(true);
+
+      // Supports ERC-165 interface
+      expect(
+        await dao.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IERC165__factory.createInterface())
+        )
+      ).to.eq(true);
     });
   });
 

--- a/test/GovernorFactory.test.ts
+++ b/test/GovernorFactory.test.ts
@@ -12,7 +12,7 @@ import {
   GovernorModule__factory,
   GovernorFactory,
   GovernorFactory__factory,
-  IModuleFactory__factory,
+  IModuleFactoryBase__factory,
   ERC1967Proxy__factory,
 } from "../typechain-types";
 import chai from "chai";
@@ -134,7 +134,7 @@ describe("Gov Module Factory", function () {
         govFactory
           .connect(executor1)
           .addVersion("1.0.1", "hash/uir", govModuleImpl.address)
-      ).to.be.revertedWith("NotAuthorized()");
+      ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("Returns current version", async () => {
@@ -264,7 +264,7 @@ describe("Gov Module Factory", function () {
       expect(
         await govFactory.supportsInterface(
           // eslint-disable-next-line camelcase
-          getInterfaceSelector(IModuleFactory__factory.createInterface())
+          getInterfaceSelector(IModuleFactoryBase__factory.createInterface())
         )
       ).to.eq(true);
       // Supports ERC-165 interface

--- a/test/GovernorFactory.test.ts
+++ b/test/GovernorFactory.test.ts
@@ -14,6 +14,7 @@ import {
   GovernorFactory__factory,
   IModuleFactoryBase__factory,
   ERC1967Proxy__factory,
+  IERC165__factory,
 } from "../typechain-types";
 import chai from "chai";
 import { ethers, network } from "hardhat";
@@ -267,8 +268,14 @@ describe("Gov Module Factory", function () {
           getInterfaceSelector(IModuleFactoryBase__factory.createInterface())
         )
       ).to.eq(true);
+
       // Supports ERC-165 interface
-      expect(await govFactory.supportsInterface("0x01ffc9a7")).to.eq(true);
+      expect(
+        await dao.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IERC165__factory.createInterface())
+        )
+      ).to.eq(true);
     });
   });
 


### PR DESCRIPTION
This PR:
 - Updates the Governor contracts to use the new ERC165Storage pattern utilized in the fractal core contracts
 - Makes the Timelock contract now also support ERC165
 - Note that the GovernorModule contract still needs to override the `supportsInterface` function, since it inherits from OZ's GovernorUpgradeable which inherits from ERC165