### PR TITLE
Update core contracts npm package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fractal-framework/module-governor",
       "version": "0.1.0",
       "devDependencies": {
-        "@fractal-framework/core-contracts": "^0.1.3",
+        "@fractal-framework/core-contracts": "^0.1.4",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
         "@nomiclabs/hardhat-etherscan": "^2.1.8",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@fractal-framework/core-contracts": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.3.tgz",
-      "integrity": "sha512-32hz/aRgmQD7LmT0GVNMt8Al3lqa8RrrmFJCwsK8aSD3IqQbertUmXNe6gCZbXphZQlSu0pIwzM/b+WoIVpcpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.4.tgz",
+      "integrity": "sha512-eE2jd2rcZSdgJ/ESyfzsVE434W9I4aZ3UdjrkhCryYGj0F7gPKbE+HS2BYPtmbQTmFpDjQgo8YtuJVfVR4Romw==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -24447,9 +24447,9 @@
       }
     },
     "@fractal-framework/core-contracts": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.3.tgz",
-      "integrity": "sha512-32hz/aRgmQD7LmT0GVNMt8Al3lqa8RrrmFJCwsK8aSD3IqQbertUmXNe6gCZbXphZQlSu0pIwzM/b+WoIVpcpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.4.tgz",
+      "integrity": "sha512-eE2jd2rcZSdgJ/ESyfzsVE434W9I4aZ3UdjrkhCryYGj0F7gPKbE+HS2BYPtmbQTmFpDjQgo8YtuJVfVR4Romw==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "hardhat test"
   },
   "devDependencies": {
-    "@fractal-framework/core-contracts": "^0.1.3",
+    "@fractal-framework/core-contracts": "^0.1.4",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",


### PR DESCRIPTION
This PR updates the fractal core contracts npm package version from 0.1.3 to 0.1.4