### PR TITLE
Bug fix

### DIFF
--- a/contracts/Governor/Timelock.sol
+++ b/contracts/Governor/Timelock.sol
@@ -44,10 +44,6 @@ contract Timelock is ModuleBase, ITimelock {
     /// - the caller must be authorized.
     /// @param newDelay Update the delay between queue and execute
     function updateDelay(uint256 newDelay) external virtual authorized {
-        require(
-            msg.sender == address(this),
-            "TimelockController: caller must be timelock"
-        );
         emit MinDelayChange(minDelay, newDelay);
         minDelay = newDelay;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fractal-framework/module-governor",
       "version": "0.1.0",
       "devDependencies": {
-        "@fractal-framework/core-contracts": "^0.1.7",
+        "@fractal-framework/core-contracts": "^0.1.9",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@fractal-framework/core-contracts": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.7.tgz",
-      "integrity": "sha512-4VIjkDYsutFqqaJno0+haUcQodO0R6GVdWjoJGrkL6IKeR8byNXOGz1QdpVhxo8o4BK/93e0JcvR220A0pqugg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.9.tgz",
+      "integrity": "sha512-SOzQvXVpJFBa+nwPKCzlkA/dm0DolBNU5DRppJB7/ce+dQJNS3X0+mytcqbd/97JXnGDK+Adew7iCjObK3BiQQ==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -24482,9 +24482,9 @@
       }
     },
     "@fractal-framework/core-contracts": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.7.tgz",
-      "integrity": "sha512-4VIjkDYsutFqqaJno0+haUcQodO0R6GVdWjoJGrkL6IKeR8byNXOGz1QdpVhxo8o4BK/93e0JcvR220A0pqugg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.9.tgz",
+      "integrity": "sha512-SOzQvXVpJFBa+nwPKCzlkA/dm0DolBNU5DRppJB7/ce+dQJNS3X0+mytcqbd/97JXnGDK+Adew7iCjObK3BiQQ==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "hardhat test"
   },
   "devDependencies": {
-    "@fractal-framework/core-contracts": "^0.1.7",
+    "@fractal-framework/core-contracts": "^0.1.9",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",


### PR DESCRIPTION
This PR:
 - Fixes a bug identified by the security audit - removes a require statement that prevents the updateDelay function from being called. Note that the function still is permissioned as it uses the authorized modifier
 - Updates the tests to make sure that a passing DAO proposal can call this function, and that it cannot be called by addresses that aren't authorized
 - Updates the core contracts npm package version